### PR TITLE
Migrate rdo-netbox to CFTPTL ADO agents.

### DIFF
--- a/pipeline-templates/copy_files.yaml
+++ b/pipeline-templates/copy_files.yaml
@@ -1,7 +1,7 @@
 jobs:
   - job: Init
     pool:
-        name: rdo-backup-prod
+        name: hmcts-cftptl-agent-pool
         vmImage: Ubuntu-18.04
 
     steps:

--- a/pipeline-templates/deploy.yaml
+++ b/pipeline-templates/deploy.yaml
@@ -1,7 +1,7 @@
 jobs:
   - job: Populate_Netbox
     pool:
-        name: rdo-backup-prod
+        name: hmcts-cftptl-agent-pool
         vmImage: Ubuntu-18.04
 
     steps:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-3734

### Change description ###

Migrate rdo-netbox pipeline (https://dev.azure.com/hmcts/PlatformOperations/_build?definitionId=345) from rdo-backup ADO agents which is offline to CFTPTL ADO agents.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
