### PR TITLE
DTSPO-14224 - Update max_memory_reserved

### DIFF
--- a/components/netbox/inputs-required.tf
+++ b/components/netbox/inputs-required.tf
@@ -42,5 +42,5 @@ variable "env" {
 
 }
 variable "collation" {
-  default = "en_GB.utf8"
+  default = "en_US.utf8"
 }

--- a/components/netbox/redis.tf
+++ b/components/netbox/redis.tf
@@ -9,6 +9,7 @@ module "redis" {
   business_area       = "sds"
   family              = "C"
   sku_name            = "Standard"
+  max_memory_reserved = "125"
 
   private_endpoint_enabled      = true
   public_network_access_enabled = false

--- a/components/netbox/redis.tf
+++ b/components/netbox/redis.tf
@@ -10,6 +10,7 @@ module "redis" {
   family              = "C"
   sku_name            = "Standard"
   maxmemory_reserved  = "125"
+  maxmemory_delta     = "125"
 
   private_endpoint_enabled      = true
   public_network_access_enabled = false

--- a/components/netbox/redis.tf
+++ b/components/netbox/redis.tf
@@ -9,7 +9,7 @@ module "redis" {
   business_area       = "sds"
   family              = "C"
   sku_name            = "Standard"
-  max_memory_reserved = "125"
+  maxmemory_reserved  = "125"
 
   private_endpoint_enabled      = true
   public_network_access_enabled = false


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14224

### Change description ###
Update value to one that works
Current setting throws error in netbox ` Cycle in the exception chain detected: exception 'command not allowed when used memory > 'maxmemory'.' encountered again`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
